### PR TITLE
Add dedicated continuous integration configuration for HGNC

### DIFF
--- a/.github/workflows/hgnc.yml
+++ b/.github/workflows/hgnc.yml
@@ -1,0 +1,35 @@
+name: Build HGNC
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"  # weekly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.3.1
+    strategy:
+      max-parallel: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Update Git Configuration
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build HGNC resources
+        id: update
+        run: |
+          uv run build.py -x hgnc -x hgnc.genegroup
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: '🧬 Update HGNC'
+          default_author: github_actions


### PR DESCRIPTION
As a follow-up to #23, this PR adds a dedicated continuous integration configuration for HGNC (`hgnc.yml`) such that the HGNC Gene and HGNC Gene Group ontology artifacts are built on a weekly basis, independent from the full build pipeline. 

It also adds a "workflow dispatch" option which lets it be run at any time from the https://github.com/biopragmatics/obo-db-ingest/actions/workflows/hgnc.yml

cc @emmaco